### PR TITLE
Include files were not being copied to the x64 build

### DIFF
--- a/.ci/build.ps1
+++ b/.ci/build.ps1
@@ -31,7 +31,7 @@ Move-Item steamworks_sdk\public\steam\lib\linux32\*.so .dist\x86\lib\steam\
 mkdir .dist\x64\bin\steam | Out-Null
 mkdir .dist\x64\lib\steam | Out-Null
 mkdir .dist\x64\include\steam | Out-Null
-Copy-Item .dist\x86\include\steam .dist\x64\include\steam
+Copy-Item .dist\x86\include\steam\*.h .dist\x64\include\steam
 Move-Item steamworks_sdk\redistributable_bin\win64\*.lib .dist\x64\lib\steam\
 Move-Item steamworks_sdk\redistributable_bin\win64\*.dll .dist\x64\bin\steam\
 Move-Item steamworks_sdk\redistributable_bin\linux64\*.so .dist\x64\bin\steam\

--- a/.ci/build.ps1
+++ b/.ci/build.ps1
@@ -31,6 +31,7 @@ Move-Item steamworks_sdk\public\steam\lib\linux32\*.so .dist\x86\lib\steam\
 mkdir .dist\x64\bin\steam | Out-Null
 mkdir .dist\x64\lib\steam | Out-Null
 mkdir .dist\x64\include\steam | Out-Null
+Copy-Item .dist\x86\include\steam .dist\x64\include\steam
 Move-Item steamworks_sdk\redistributable_bin\win64\*.lib .dist\x64\lib\steam\
 Move-Item steamworks_sdk\redistributable_bin\win64\*.dll .dist\x64\bin\steam\
 Move-Item steamworks_sdk\redistributable_bin\linux64\*.so .dist\x64\bin\steam\

--- a/cmake/FindSteamworksSDK.cmake
+++ b/cmake/FindSteamworksSDK.cmake
@@ -7,6 +7,7 @@ if (NOT STEAMWORKSSDK_FOUND)
 		steam_api64
 		PATH_SUFFIXES
 		lib/steam
+		vendor/lib/steam
 	)
 
 	find_path(
@@ -14,6 +15,7 @@ if (NOT STEAMWORKSSDK_FOUND)
 		steam
 		PATH_SUFFIXES
 		include
+		vendor/include
 	)
 
 	add_library(STEAMWORKSSDK::STEAMWORKSSDK STATIC IMPORTED)
@@ -35,6 +37,7 @@ if (NOT STEAMWORKSSDK_FOUND)
 		sdkencryptedappticket64
 		PATH_SUFFIXES
 		lib/steam
+		vendor/lib/steam
 	)
 
 	add_library(STEAMWORKSSDK::APPTICKET STATIC IMPORTED)


### PR DESCRIPTION
The include files were being moved once to the x86 build and not added to the x64 build, a `Copy-Item` was added to solve this problem.

The path suffixes in FindSteamworksSDK.cmake were not including the proposed path in CMakeLists.txt file (using `vendor` as install dir)